### PR TITLE
to allow Request header field Authorization

### DIFF
--- a/hack/docker/elasticsearch/5.6.4/config/elasticsearch.yml
+++ b/hack/docker/elasticsearch/5.6.4/config/elasticsearch.yml
@@ -22,6 +22,8 @@ http:
   cors:
     enabled: ${HTTP_CORS_ENABLE}
     allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
+    allow-credentials: true
+    allow-headers: "X-Requested-With, Content-Type, Content-Length, Authorization"
 
 discovery:
   zen:


### PR DESCRIPTION
Why need this configuration, check this issue in https://github.com/elastic/elasticsearch/issues/9063#issuecomment-68731642

Issue filed in https://github.com/kubedb/project/issues/158