### PR TITLE
fix gke-version

### DIFF
--- a/hack/concourse/Dockerfile
+++ b/hack/concourse/Dockerfile
@@ -11,13 +11,14 @@ RUN apt-get update && apt-get install -y \
     libdevmapper-dev \
     iptables \
     ca-certificates \
+    cowsay \
     && \
+    mv /usr/games/cowsay /bin && \
     curl -fL "https://download.docker.com/linux/static/${DOCKER_CHANNEL}/x86_64/docker-${DOCKER_VERSION}.tgz" | tar zx && \
     mv docker/* /bin/ && chmod +x /bin/docker* && \
     rm -rf /var/cache/apt/* && \
     rm -rf /root/.cache
 
-COPY entrypoint.sh /bin/entrypoint.sh
 RUN curl -LO https://gist.githubusercontent.com/tahsinrahman/db0626153488f88ceac544404f33cc0f/raw/f9ba010b5dd194dbbf96f1431e5d8a46966ed79a/entrypoint.sh && \
     chmod +x entrypoint.sh && \
     mv entrypoint.sh /bin/

--- a/hack/concourse/pipeline.yml
+++ b/hack/concourse/pipeline.yml
@@ -26,7 +26,7 @@ resources:
     bucket: kubedbci
     access_key_id: ((s3-access-key))
     secret_access_key: ((s3-secret))
-    versioned_file: gcs.zip
+    versioned_file: creds.zip
 
 jobs:
 - name: test-elasticsearch
@@ -43,21 +43,6 @@ jobs:
       TOKEN: ((digitaloceanToken))
       DOCKER_USER: ((docker_user))
       DOCKER_PASS: ((docker_pass))
-      AWS_KEY_ID: ((aws_key_id))
-      AWS_SECRET: ((aws_secret))
-      S3_BUCKET_NAME: ((s3_bucket_name))
-      GCE_PROJECT_ID: ((gce_project_id))
-      GCS_BUCKET_NAME: ((gcs_bucket_name))
-      AZURE_ACCOUNT_NAME: ((azure_account_name))
-      AZURE_ACCOUNT_KEY: ((azure_account_key))
-      AZURE_CONTAINER_NAME: ((azure_container_name))
-      OS_AUTH_URL: ((os_auth_url))
-      OS_TENANT_ID: ((os_tenant_id))
-      OS_TENANT_NAME: ((os_tenaant_name))
-      OS_USERNAME: ((os_username))
-      OS_PASSWORD: ((os_password))
-      OS_REGION_NAME: ((os_region_name))
-      SWIFT_CONTAINER_NAME: ((swift_container_name))
 
 - name: test-elasticsearch-pr
   plan:
@@ -77,21 +62,6 @@ jobs:
       TOKEN: ((digitaloceanToken))
       DOCKER_USER: ((docker_user))
       DOCKER_PASS: ((docker_pass))
-      AWS_KEY_ID: ((aws_key_id))
-      AWS_SECRET: ((aws_secret))
-      S3_BUCKET_NAME: ((s3_bucket_name))
-      GCE_PROJECT_ID: ((gce_project_id))
-      GCS_BUCKET_NAME: ((gcs_bucket_name))
-      AZURE_ACCOUNT_NAME: ((azure_account_name))
-      AZURE_ACCOUNT_KEY: ((azure_account_key))
-      AZURE_CONTAINER_NAME: ((azure_container_name))
-      OS_AUTH_URL: ((os_auth_url))
-      OS_TENANT_ID: ((os_tenant_id))
-      OS_TENANT_NAME: ((os_tenaant_name))
-      OS_USERNAME: ((os_username))
-      OS_PASSWORD: ((os_password))
-      OS_REGION_NAME: ((os_region_name))
-      SWIFT_CONTAINER_NAME: ((swift_container_name))
     on_success:
       put: pull-request
       params: { path: pull-request, status: success}

--- a/hack/concourse/task.yml
+++ b/hack/concourse/task.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: 1gtm/kubedb
+    repository: appscodeci/dind
     tag: latest
 
 inputs:

--- a/hack/concourse/test.sh
+++ b/hack/concourse/test.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-set -x -e
+set -eoux pipefail
+
+set +x
+DOCKER_USER=${DOCKER_USER:-}
+DOCKER_PASS=${DOCKER_PASS:-}
 
 # start docker and log-in to docker-hub
 entrypoint.sh
 docker login --username=$DOCKER_USER --password=$DOCKER_PASS
+set -x
 docker run hello-world
-
-# install python pip
-apt-get update > /dev/null
-apt-get install -y python python-pip > /dev/null
 
 # install kubectl
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &> /dev/null
@@ -22,37 +23,46 @@ curl -fsSL -o onessl https://github.com/kubepack/onessl/releases/download/0.3.0/
   && mv onessl /usr/local/bin/
 
 # install pharmer
-pushd /tmp
-curl -LO https://cdn.appscode.com/binaries/pharmer/0.1.0-rc.4/pharmer-linux-amd64
-chmod +x pharmer-linux-amd64
-mv pharmer-linux-amd64 /bin/pharmer
+mkdir -p $GOPATH/src/github.com/pharmer
+pushd $GOPATH/src/github.com/pharmer
+git clone https://github.com/pharmer/pharmer
+cd pharmer
+./hack/builddeps.sh
+./hack/make.py
 popd
 
 function cleanup {
+    set +e
+
     # Workload Descriptions if the test fails
-    if [ $? -ne 0 ]; then
-        echo ""
-        kubectl describe deploy -n kube-system -l app=kubedb || true
-        echo ""
-        echo ""
-        kubectl describe replicasets -n kube-system -l app=kubedb || true
-        echo ""
-        echo ""
-        kubectl describe pods -n kube-system -l app=kubedb || true
-    fi
+    cowsay "describe deployment"
+    kubectl describe deploy -n kube-system -l app=kubedb
+    cowsay "describe replicaset"
+    kubectl describe replicasets -n kube-system -l app=kubedb
+    cowsay "describe pods"
+    kubectl describe pods -n kube-system -l app=kubedb
+    cowsay "describe nodes"
+    kubectl get nodes
+    kubectl describe nodes
+
+    # delete operator
+    pushd $GOPATH/src/github.com/kubedb/elasticsearch
+    ./hack/deploy/setup.sh --uninstall --purge
+    popd
 
     # delete cluster on exit
-    pharmer get cluster || true
-    pharmer delete cluster $NAME || true
-    pharmer get cluster || true
-    sleep 120 || true
-    pharmer apply $NAME || true
-    pharmer get cluster || true
+    pharmer get cluster
+    pharmer delete cluster $NAME
+    pharmer get cluster
+    sleep 300
+    pharmer apply $NAME
+    pharmer get cluster
 
     # delete docker image on exit
-    curl -LO https://raw.githubusercontent.com/appscodelabs/libbuild/master/docker.py || true
-    chmod +x docker.py || true
-    ./docker.py del_tag kubedbci es-operator $CUSTOM_OPERATOR_TAG || true
+    curl -LO https://raw.githubusercontent.com/appscodelabs/libbuild/master/docker.py
+    chmod +x docker.py
+    CUSTOM_OPERATOR_TAG=${CUSTOM_OPERATOR_TAG:-}
+    ./docker.py del_tag kubedbci es-operator $CUSTOM_OPERATOR_TAG
 }
 trap cleanup EXIT
 
@@ -75,53 +85,20 @@ export DOCKER_REGISTRY=kubedbci
 popd
 
 #create cluster using pharmer
-pharmer create credential --from-file=creds/gcs/gke.json --provider=GoogleCloud cred
-pharmer create cluster $NAME --provider=gke --zone=us-central1-f --nodes=n1-standard-2=1 --credential-uid=cred --v=10 --kubernetes-version=1.10.2-gke.3
+pharmer create credential --from-file=creds/gke.json --provider=GoogleCloud cred
+pharmer create cluster $NAME --provider=gke --zone=us-central1-f --nodes=n1-standard-2=1 --credential-uid=cred --v=10 --kubernetes-version=1.10.4-gke.2
 pharmer apply $NAME
-
-# gcloud-sdk
-pushd /tmp
-curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-202.0.0-linux-x86_64.tar.gz
-tar --extract --file google-cloud-sdk-202.0.0-linux-x86_64.tar.gz
-CLOUDSDK_CORE_DISABLE_PROMPTS=1 ./google-cloud-sdk/install.sh
-source /tmp/google-cloud-sdk/path.bash.inc
-popd
-gcloud auth activate-service-account --key-file creds/gcs/gke.json
-gcloud container clusters get-credentials $NAME --zone us-central1-f --project k8s-qa
-kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=k8s-qa@k8s-qa.iam.gserviceaccount.com
 
 #wait for cluster to be ready
 sleep 300
+pharmer use cluster $NAME
 kubectl get nodes
 
-export CRED_DIR=$(pwd)/creds/gcs/gcs.json
+# create config/.env file that have all necessary creds
+cp creds/gcs.json /gcs.json
+cp creds/.env $GOPATH/src/github.com/kubedb/elasticsearch/hack/config/.env
 
 pushd $GOPATH/src/github.com/kubedb/elasticsearch
-
-# create config/.env file that have all necessary creds
-cat > hack/config/.env <<EOF
-AWS_ACCESS_KEY_ID=$AWS_KEY_ID
-AWS_SECRET_ACCESS_KEY=$AWS_SECRET
-
-GOOGLE_PROJECT_ID=$GCE_PROJECT_ID
-GOOGLE_APPLICATION_CREDENTIALS=$CRED_DIR
-
-AZURE_ACCOUNT_NAME=$AZURE_ACCOUNT_NAME
-AZURE_ACCOUNT_KEY=$AZURE_ACCOUNT_KEY
-
-OS_AUTH_URL=$OS_AUTH_URL
-OS_TENANT_ID=$OS_TENANT_ID
-OS_TENANT_NAME=$OS_TENANT_NAME
-OS_USERNAME=$OS_USERNAME
-OS_PASSWORD=$OS_PASSWORD
-OS_REGION_NAME=$OS_REGION_NAME
-
-S3_BUCKET_NAME=$S3_BUCKET_NAME
-GCS_BUCKET_NAME=$GCS_BUCKET_NAME
-AZURE_CONTAINER_NAME=$AZURE_CONTAINER_NAME
-SWIFT_CONTAINER_NAME=$SWIFT_CONTAINER_NAME
-EOF
-
 
 # run tests
 ./hack/builddeps.sh
@@ -129,22 +106,6 @@ export APPSCODE_ENV=dev
 export DOCKER_REGISTRY=kubedbci
 source ./hack/deploy/setup.sh --docker-registry=kubedbci
 
-./hack/make.py test e2e --v=1 --storageclass=standard --selfhosted-operator=true --es-version=6.2.4
-
-kubectl describe pods -n kube-system -l app=kubedb || true
-echo ""
-echo "::::::::::::::::::::::::::: Describe Nodes :::::::::::::::::::::::::::"
-echo ""
-kubectl get nodes || true
-echo ""
-kubectl describe nodes || true
-
 ./hack/make.py test e2e --v=1 --storageclass=standard --selfhosted-operator=true
 
-kubectl describe pods -n kube-system -l app=kubedb || true
-echo ""
-echo "::::::::::::::::::::::::::: Describe Nodes :::::::::::::::::::::::::::"
-echo ""
-kubectl get nodes || true
-echo ""
-kubectl describe nodes || true
+popd

--- a/hack/concourse/test.sh
+++ b/hack/concourse/test.sh
@@ -108,5 +108,6 @@ export DOCKER_REGISTRY=kubedbci
 source ./hack/deploy/setup.sh --docker-registry=kubedbci
 
 ./hack/make.py test e2e --v=1 --storageclass=standard --selfhosted-operator=true
+#./hack/make.py test e2e --v=1 --storageclass=standard --selfhosted-operator=true --es-version=6.2.4
 
 popd

--- a/hack/concourse/test.sh
+++ b/hack/concourse/test.sh
@@ -50,6 +50,13 @@ function cleanup {
     ./hack/deploy/setup.sh --uninstall --purge
     popd
 
+    # delete docker image on exit
+    curl -LO https://raw.githubusercontent.com/appscodelabs/libbuild/master/docker.py
+    chmod +x docker.py
+    CUSTOM_OPERATOR_TAG=${CUSTOM_OPERATOR_TAG:-}
+    ./docker.py del_tag kubedbci es-operator $CUSTOM_OPERATOR_TAG
+
+    set -e
     # delete cluster on exit
     pharmer get cluster
     pharmer delete cluster $NAME
@@ -57,12 +64,6 @@ function cleanup {
     sleep 300
     pharmer apply $NAME
     pharmer get cluster
-
-    # delete docker image on exit
-    curl -LO https://raw.githubusercontent.com/appscodelabs/libbuild/master/docker.py
-    chmod +x docker.py
-    CUSTOM_OPERATOR_TAG=${CUSTOM_OPERATOR_TAG:-}
-    ./docker.py del_tag kubedbci es-operator $CUSTOM_OPERATOR_TAG
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
* updated gke cluster to `1.10.4-gke.2` from `1.10.2-gke.3` to fix error `googleapi: Error 400: master version "1.10.2-gke.3" is unsupported., badRequest`
* build pharmer from source which supports gke
* use `config/.env` file from bucket instead of env. variables from pipeline, which removes duplication and simplifies pipelien
* hide docker username and password from concourse-logs
* running tests only once instead of twice
* use `cowsay` instead of long echo, eg `cowsay 'discribe nodes` for `echo :::::::::::::describe node:::::::::::::: `