### PR TITLE
Use Search Guard 23.0 for Elasticsearch 6.3

### DIFF
--- a/hack/docker/elasticsearch/6.3.0/Dockerfile
+++ b/hack/docker/elasticsearch/6.3.0/Dockerfile
@@ -10,7 +10,7 @@ ENV NODE_NAME="" \
 RUN ./bin/elasticsearch-plugin install --batch ingest-attachment
 
 # Install search-guard
-RUN ./bin/elasticsearch-plugin install --batch -b com.floragunn:search-guard-6:6.3.0-22.3
+RUN ./bin/elasticsearch-plugin install --batch -b com.floragunn:search-guard-6:6.3.0-23.0
 
 RUN chmod +x -R plugins/search-guard-6/tools/*.sh
 

--- a/pkg/controller/secret.go
+++ b/pkg/controller/secret.go
@@ -239,7 +239,7 @@ searchguard:
           type: basic
           challenge: true
         authentication_backend:
-          type: intern
+          type: internal
 `
 
 var internal_user = `


### PR DESCRIPTION
Task:
- [x] Use search guard 23.0 for ES 6.3
- [x] Fix typo in `sg_config` of secret