### PR TITLE
Set `USE_SSL` env in exporter container

### DIFF
--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -509,6 +509,21 @@ func (c *Controller) upsertMonitoringContainer(statefulSet *apps.StatefulSet, el
 		volumes := statefulSet.Spec.Template.Spec.Volumes
 		volumes = core_util.UpsertVolume(volumes, volume)
 		statefulSet.Spec.Template.Spec.Volumes = volumes
+
+		// this environment variable will be used to determine url scheme in exporter
+		envList := []core.EnvVar{
+			{
+				Name:  "SSL_ENABLE",
+				Value: fmt.Sprintf("%v", elasticsearch.Spec.EnableSSL),
+			},
+		}
+
+		for i, container := range statefulSet.Spec.Template.Spec.Containers {
+			if container.Name == "exporter" {
+				statefulSet.Spec.Template.Spec.Containers[i].Env = core_util.UpsertEnvVars(container.Env, envList...)
+				return statefulSet
+			}
+		}
 	}
 	return statefulSet
 }

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -513,7 +513,7 @@ func (c *Controller) upsertMonitoringContainer(statefulSet *apps.StatefulSet, el
 		// this environment variable will be used to determine url scheme in exporter
 		envList := []core.EnvVar{
 			{
-				Name:  "SSL_ENABLE",
+				Name:  "USE_SSL",
 				Value: fmt.Sprintf("%v", elasticsearch.Spec.EnableSSL),
 			},
 		}


### PR DESCRIPTION
This PR set `SSL_ENABLE` environment variable in exporter container so that it can be used to determine url scheme in exporter.
Fixes: https://github.com/kubedb/project/issues/246