### PR TITLE
Add missing privileges for ES snapshot

### DIFF
--- a/pkg/controller/secret.go
+++ b/pkg/controller/secret.go
@@ -209,9 +209,12 @@ CLUSTER_COMPOSITE_OPS_RO:
 
 CLUSTER_KUBEDB_SNAPSHOT:
   - "indices:data/read/scroll*"
+  - "cluster:monitor/main"
 
 INDICES_KUBEDB_SNAPSHOT:
   - "indices:admin/get"
+  - "indices:monitor/settings/get"
+  - "indices:admin/mappings/get"
 `
 
 var config = `


### PR DESCRIPTION
Add missing privileges for ES snapshot, as the current set
(set via Security Guard) appears to be too restrictive to run
a successful snapshot.

fixes https://github.com/kubedb/project/issues/394