### PR TITLE
Add support for Elasticsearch 6.8.0

### DIFF
--- a/hack/docker/elasticsearch-tools/6.8.0/Dockerfile
+++ b/hack/docker/elasticsearch-tools/6.8.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8.14-alpine
+
+RUN set -x \
+  && apk add --update --no-cache bash ca-certificates
+
+RUN npm install elasticdump@4.1.2 -g
+
+COPY osm /usr/local/bin/osm
+COPY elasticsearch-tools.sh /usr/local/bin/elasticsearch-tools.sh
+
+ENTRYPOINT ["elasticsearch-tools.sh"]

--- a/hack/docker/elasticsearch-tools/6.8.0/elasticsearch-tools.sh
+++ b/hack/docker/elasticsearch-tools/6.8.0/elasticsearch-tools.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -eou pipefail
+
+# ref: https://stackoverflow.com/a/7069755/244009
+# ref: https://jonalmeida.com/posts/2013/05/26/different-ways-to-implement-flags-in-bash/
+# ref: http://tldp.org/LDP/abs/html/comparison-ops.html
+
+show_help() {
+  echo "elasticsearch-tools.sh - run tools"
+  echo " "
+  echo "elasticsearch-tools.sh COMMAND [options]"
+  echo " "
+  echo "options:"
+  echo "-h, --help                         show brief help"
+  echo "    --data-dir=DIR                 path to directory holding db data (default: /var/data)"
+  echo "    --host=HOST                    database host"
+  echo "    --user=USERNAME                database username"
+  echo "    --indices=INDICES              elasticsearch indices"
+  echo "    --bucket=BUCKET                name of bucket"
+  echo "    --folder=FOLDER                name of folder in bucket"
+  echo "    --snapshot=SNAPSHOT            name of snapshot"
+  echo "    --enable-analytics=ENABLE_ANALYTICS   send analytical events to Google Analytics (default true)"
+}
+
+RETVAL=0
+DEBUG=${DEBUG:-}
+DB_HOST=${DB_HOST:-}
+DB_PORT=${DB_PORT:-9200}
+DB_USER=${DB_USER:-}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_INDICES=${DB_INDICES:-}
+DB_BUCKET=${DB_BUCKET:-}
+DB_FOLDER=${DB_FOLDER:-}
+DB_SNAPSHOT=${DB_SNAPSHOT:-}
+DB_DATA_DIR=${DB_DATA_DIR:-/var/data}
+DB_SCHEME=${DB_SCHEME:-https}
+OSM_CONFIG_FILE=/etc/osm/config
+ENABLE_ANALYTICS=${ENABLE_ANALYTICS:-true}
+
+ES_AUTH_NONE="None"
+ES_AUTH_SEARCHGUARD="SearchGuard"
+ES_AUTH_XPACK="X-Pack"
+
+AUTH_PLUGIN=${AUTH_PLUGIN:-$ES_AUTH_SEARCHGUARD}
+ES_URL=${ES_URL:-}
+
+op=$1
+shift
+
+while test $# -gt 0; do
+  case "$1" in
+    -h | --help)
+      show_help
+      exit 0
+      ;;
+    --data-dir*)
+      export DB_DATA_DIR=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --host*)
+      export DB_HOST=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --user*)
+      export DB_USER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --indices*)
+      export DB_INDICES=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --bucket*)
+      export DB_BUCKET=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --folder*)
+      export DB_FOLDER=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --snapshot*)
+      export DB_SNAPSHOT=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --analytics* | --enable-analytics*)
+      export ENABLE_ANALYTICS=$(echo $1 | sed -e 's/^[^=]*=//g')
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+case "$AUTH_PLUGIN" in
+  "$ES_AUTH_NONE")
+    ES_URL=$(echo "${DB_SCHEME}://${DB_HOST}:${DB_PORT}")
+    ;;
+  "$ES_AUTH_SEARCHGUARD")
+    ES_URL=$(echo "${DB_SCHEME}://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}")
+    ;;
+esac
+
+if [ -n "$DEBUG" ]; then
+  env | sort | grep DB_*
+  echo ""
+fi
+
+# cleanup data dump dir
+mkdir -p "$DB_DATA_DIR"
+cd "$DB_DATA_DIR"
+rm -rf *
+
+function exit_on_error() {
+  echo "$1"
+  exit 1
+}
+
+# Wait for elasticsearch to start
+# ref: http://unix.stackexchange.com/a/5279
+while ! nc "$DB_HOST" "$DB_PORT" -w 60 >/dev/null; do
+  echo "Waiting... database is not ready yet"
+  sleep 5
+done
+
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+
+case "$op" in
+  backup)
+    echo "Starting backup......"
+
+    IFS=$','
+    for INDEX in $(echo "$DB_INDICES"); do
+      echo "Dumping index: $INDEX"
+
+      elasticdump --quiet --input "$ES_URL/$INDEX" --output "$INDEX.mapping.json" --type mapping "$@" || exit_on_error "failed to dump mapping for $INDEX"
+      elasticdump --quiet --input "$ES_URL/$INDEX" --output "$INDEX.analyzer.json" --type analyzer "$@" || exit_on_error "failed to dump analyzer for $INDEX"
+      elasticdump --quiet --input "$ES_URL/$INDEX" --output "$INDEX.data.json" --type data "$@" || exit_on_error "failed to dump data for $INDEX"
+
+      echo "$INDEX" >>indices.txt
+    done
+
+    echo "Pushing data into backed....."
+    osm push --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_DATA_DIR" "$DB_FOLDER/$DB_SNAPSHOT" || exit_on_error "failed to push data"
+
+    echo "Backup successful"
+    ;;
+  restore)
+    echo "Starting restore process....."
+
+    osm pull --enable-analytics="$ENABLE_ANALYTICS" --osmconfig="$OSM_CONFIG_FILE" -c "$DB_BUCKET" "$DB_FOLDER/$DB_SNAPSHOT" "$DB_DATA_DIR" || exit_on_error "failed to pull data"
+
+    IFS=$'\n'
+    for INDEX in $(cat indices.txt); do
+      echo "Restoring index: $INDEX"
+
+      elasticdump --quiet --input "$INDEX.analyzer.json" --output "$ES_URL/$INDEX" --type analyzer "$@" || exit_on_error "failed to restore analyzer for $INDEX"
+      elasticdump --quiet --input "$INDEX.mapping.json" --output "$ES_URL/$INDEX" --type mapping "$@" || exit_on_error "failed to restore mapping for $INDEX"
+      elasticdump --quiet --input "$INDEX.data.json" --output "$ES_URL/$INDEX" --type data "$@" || exit_on_error "failed to restore data for $INDEX"
+    done
+
+    echo "Successfully restored"
+    ;;
+  *)
+    (10)
+    echo $"Unknown op!"
+    RETVAL=1
+    ;;
+esac
+exit "$RETVAL"

--- a/hack/docker/elasticsearch-tools/6.8.0/make.sh
+++ b/hack/docker/elasticsearch-tools/6.8.0/make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -xeou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT=$GOPATH/src/github.com/kubedb/elasticsearch
+
+source "$REPO_ROOT/hack/libbuild/common/lib.sh"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=elasticsearch-tools
+DB_VERSION=6.8.0
+TAG="$DB_VERSION"
+OSM_VER=${OSM_VER:-0.9.1}
+
+DIST="$REPO_ROOT/dist"
+mkdir -p "$DIST"
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/elasticsearch-tools/$DB_VERSION"
+
+  # Download osm
+  wget https://cdn.appscode.com/binaries/osm/${OSM_VER}/osm-alpine-amd64
+  chmod +x osm-alpine-amd64
+  mv osm-alpine-amd64 osm
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm osm
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/elasticsearch/6.8.0/Dockerfile
+++ b/hack/docker/elasticsearch/6.8.0/Dockerfile
@@ -1,0 +1,103 @@
+FROM openjdk:8u181-alpine
+
+ENV ES_VERSION 6.8.0
+
+ENV DOWNLOAD_URL "https://artifacts.elastic.co/downloads/elasticsearch"
+ENV ES_TARBAL "${DOWNLOAD_URL}/elasticsearch-${ES_VERSION}.tar.gz"
+ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/elasticsearch-${ES_VERSION}.tar.gz.asc"
+ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
+
+# Install necessary tools
+RUN apk add --no-cache --update bash ca-certificates su-exec util-linux curl runit
+
+# Install Elasticsearch.
+RUN apk add --no-cache -t .build-deps gnupg openssl \
+  && cd /tmp \
+  && echo "===> Install Elasticsearch..." \
+  && curl -o elasticsearch.tar.gz -Lskj "$ES_TARBAL"; \
+	if [ "$ES_TARBALL_ASC" ]; then \
+		curl -o elasticsearch.tar.gz.asc -Lskj "$ES_TARBALL_ASC"; \
+		export GNUPGHOME="$(mktemp -d)"; \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY"; \
+		gpg --batch --verify elasticsearch.tar.gz.asc elasticsearch.tar.gz; \
+		rm -r "$GNUPGHOME" elasticsearch.tar.gz.asc; \
+	fi; \
+  tar -xf elasticsearch.tar.gz \
+  && ls -lah \
+  && mv elasticsearch-$ES_VERSION /elasticsearch \
+  && adduser -DH -s /sbin/nologin elasticsearch \
+  && mkdir -p /elasticsearch/config/scripts /elasticsearch/plugins \
+  && chown -R elasticsearch:elasticsearch /elasticsearch \
+  && rm -rf /tmp/* \
+  && apk del --purge .build-deps
+
+# Add Elasticsearch to PATH
+ENV PATH /elasticsearch/bin:$PATH
+
+# Set default working directory to /elasticsearch
+WORKDIR /elasticsearch
+
+# Set environment variables defaults
+ENV NODE_NAME="" \
+    ES_TMPDIR="/elasticsearch/tmp" \
+    ES_JAVA_OPTS="-Xms512m -Xmx512m" \
+    CLUSTER_NAME="elasticsearch" \
+    NODE_MASTER=true \
+    NODE_DATA=true \
+    NODE_INGEST=true \
+    HTTP_ENABLE=true \
+    HTTP_CORS_ENABLE=true \
+    HTTP_CORS_ALLOW_ORIGIN=* \
+    DISCOVERY_SERVICE="" \
+    NUMBER_OF_MASTERS=1 \
+    SSL_ENABLE=false \
+    MODE="" \
+    NETWORK_HOST=_site_ \
+    HTTP_CORS_ENABLE=true \
+    MAX_LOCAL_STORAGE_NODES=1 \
+    SHARD_ALLOCATION_AWARENESS="" \
+    SHARD_ALLOCATION_AWARENESS_ATTR="" \
+    MEMORY_LOCK=true \
+    REPO_LOCATIONS="" \
+    KEY_PASS=""
+
+# Install mapper-attachments (https://www.elastic.co/guide/en/elasticsearch/plugins/current/ingest-attachment.html)
+RUN ./bin/elasticsearch-plugin install --batch ingest-attachment
+
+# Install search-guard
+RUN ./bin/elasticsearch-plugin install --batch -b com.floragunn:search-guard-6:6.8.0-25.1
+RUN chmod +x -R plugins/search-guard-6/tools/*.sh
+
+# Add Elasticsearch configuration files
+ADD config /elasticsearch/config
+
+# run.sh run Elasticsearch after changing ownership and some configuration
+COPY run.sh /
+RUN mkdir /etc/service/elasticsearch
+RUN ln -s /run.sh /etc/service/elasticsearch/run
+
+# fsloader watcher for any configuration changes and restart Elasticsearch if necessary
+ADD fsloader /fsloader
+RUN chmod +x /fsloader/*
+RUN mkdir /etc/service/fsloader
+RUN ln -s /fsloader/run_fsloader.sh /etc/service/fsloader/run
+
+# /elasticsearch/config/certs directory is used to mount SSL certificates
+RUN mkdir /elasticsearch/config/certs
+RUN chown elasticsearch:elasticsearch -R /elasticsearch/config/certs
+
+# yq and config-marger.sh is used to merge custom configuration files.
+COPY yq /usr/bin/yq
+COPY config-merger.sh /usr/bin/config-merger.sh
+
+# runit.sh run at Entrypoint
+COPY runit.sh /runit.sh
+
+# Volume for Elasticsearch data
+VOLUME ["/data"]
+
+# Export HTTP & Transport
+EXPOSE 9200 9300
+
+# Run "runit.sh" on start
+ENTRYPOINT ["/runit.sh"]

--- a/hack/docker/elasticsearch/6.8.0/config-merger.sh
+++ b/hack/docker/elasticsearch/6.8.0/config-merger.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -x
+CONFIG_DIR="/elasticsearch/config"
+CUSTOM_CONFIG_DIR="/elasticsearch/custom-config"
+
+CONFIG_FILE=$CONFIG_DIR/elasticsearch.yml
+
+# yq changes the file permissions after merging custom configuration.
+# we need to restore the original permissions after merging done.
+ORIGINAL_PERMISSION=$(stat -c '%a' $CONFIG_FILE)
+
+# if common-config file exist then apply it
+if [ -f $CUSTOM_CONFIG_DIR/common-config.yml ]; then
+  yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/common-config.yml
+elif [ -f $CUSTOM_CONFIG_DIR/common-config.yaml ]; then
+  yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/common-config.yaml
+fi
+
+# if it is data node and data-config file exist then apply it
+if [[ "$NODE_DATA" == true ]]; then
+  if [ -f $CUSTOM_CONFIG_DIR/data-config.yml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/data-config.yml
+  elif [ -f $CUSTOM_CONFIG_DIR/data-config.yaml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/data-config.yaml
+  fi
+fi
+
+# if it is client node and client-config file exist then apply it
+if [[ "$NODE_INGEST" == true ]]; then
+  if [ -f $CUSTOM_CONFIG_DIR/client-config.yml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/client-config.yml
+  elif [ -f $CUSTOM_CONFIG_DIR/client-config.yaml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/client-config.yaml
+  fi
+fi
+
+# if it is master node and mater-config file exist then apply it
+if [[ "$NODE_MASTER" == true ]]; then
+  if [ -f $CUSTOM_CONFIG_DIR/master-config.yml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/master-config.yml
+  elif [ -f $CUSTOM_CONFIG_DIR/master-config.yaml ]; then
+    yq merge -i --overwrite $CONFIG_FILE $CUSTOM_CONFIG_DIR/master-config.yaml
+  fi
+fi
+
+# restore original permission of elasticsearh.yml file
+chmod $ORIGINAL_PERMISSION $CONFIG_FILE

--- a/hack/docker/elasticsearch/6.8.0/config/elasticsearch.yml
+++ b/hack/docker/elasticsearch/6.8.0/config/elasticsearch.yml
@@ -1,0 +1,55 @@
+cluster:
+  name: ${CLUSTER_NAME}
+
+node:
+  master: ${NODE_MASTER}
+  data: ${NODE_DATA}
+  name: ${NODE_NAME}
+  ingest: ${NODE_INGEST}
+
+network.host: 0.0.0.0
+
+path:
+  data: /data/data
+  logs: /data/log
+
+bootstrap:
+  memory_lock: false
+
+http:
+  enabled: ${HTTP_ENABLE}
+  compression: true
+  cors:
+    enabled: ${HTTP_CORS_ENABLE}
+    allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
+    allow-credentials: true
+    allow-headers: "X-Requested-With, Content-Type, Content-Length, Authorization"
+
+discovery:
+  zen:
+    ping.unicast.hosts: ${DISCOVERY_SERVICE}
+    minimum_master_nodes: ${NUMBER_OF_MASTERS}
+
+# ref: https://github.com/floragunncom/search-guard-ssl/issues/43
+xpack.security.enabled: ${XPACK_SECURITY_ENABLED:false}
+
+######## Start Search Guard Configuration ########
+searchguard.disabled: ${SEARCHGUARD_DISABLED:false}
+
+# disable Search Guard enterprise modules by default
+searchguard.enterprise_modules_enabled: false
+
+searchguard.ssl.transport.keystore_filepath: certs/node.jks
+searchguard.ssl.transport.keystore_password: ${KEY_PASS}
+searchguard.ssl.transport.truststore_filepath: certs/root.jks
+searchguard.ssl.transport.truststore_password: ${KEY_PASS}
+searchguard.ssl.transport.enforce_hostname_verification: false
+searchguard.ssl.http.enabled: ${SSL_ENABLE}
+searchguard.ssl.http.keystore_filepath: certs/client.jks
+searchguard.ssl.http.keystore_password: ${KEY_PASS}
+searchguard.ssl.http.truststore_filepath: certs/root.jks
+searchguard.ssl.http.truststore_password: ${KEY_PASS}
+
+searchguard.authcz.admin_dn:
+  - 'CN=sgadmin,O=Elasticsearch Operator'
+######## End Search Guard Configuration ########

--- a/hack/docker/elasticsearch/6.8.0/config/log4j2.properties
+++ b/hack/docker/elasticsearch/6.8.0/config/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/hack/docker/elasticsearch/6.8.0/fsloader/run_fsloader.sh
+++ b/hack/docker/elasticsearch/6.8.0/fsloader/run_fsloader.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -x
+set -o errexit
+set -o pipefail
+
+searchguard="/elasticsearch/plugins/search-guard-6"
+
+sync
+
+if [ "$SEARCHGUARD_DISABLED" == false ]; then
+  case "$MODE" in
+    client)
+      # Run sgadmin in client node (with ordinal 0 only)
+      ordinal="${NODE_NAME##*-}"
+      if [ "$ordinal" == "0" ]; then
+        /fsloader/run_sgadmin.sh
+        exec /fsloader/fsloader run --mount-file "$searchguard"/sgconfig/sg_internal_users.yml \
+          --boot-cmd /fsloader/run_sgadmin.sh
+      fi
+      ;;
+
+    *) ;;
+  esac
+fi
+echo "Ignore running sgadmin..."
+exec tail -f /fsloader/run_sgadmin.sh

--- a/hack/docker/elasticsearch/6.8.0/fsloader/run_sgadmin.sh
+++ b/hack/docker/elasticsearch/6.8.0/fsloader/run_sgadmin.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+searchguard="/elasticsearch/plugins/search-guard-6"
+certs="/elasticsearch/config/certs"
+
+sync
+
+SERVER='http://localhost:9200'
+
+if [ "$SSL_ENABLE" == true ]; then
+  SERVER='https://localhost:9200'
+fi
+
+until curl -s "$SERVER" --insecure; do
+  sleep 0.1
+done
+
+"$searchguard"/tools/sgadmin.sh \
+  -ks "$certs"/sgadmin.jks \
+  -kspass "$KEY_PASS" \
+  -ts "$certs"/root.jks \
+  -tspass "$KEY_PASS" \
+  -cd "$searchguard"/sgconfig -icl -nhnv

--- a/hack/docker/elasticsearch/6.8.0/make.sh
+++ b/hack/docker/elasticsearch/6.8.0/make.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeou pipefail
+
+GOPATH=$(go env GOPATH)
+REPO_ROOT="$GOPATH/src/github.com/kubedb/elasticsearch"
+source "$REPO_ROOT/hack/libbuild/common/kubedb_image.sh"
+
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-kubedb}
+IMG=elasticsearch
+DB_VERSION=6.8.0
+TAG="$DB_VERSION"
+YQ_VER=${YQ_VER:-2.1.1}
+
+build() {
+  pushd "$REPO_ROOT/hack/docker/elasticsearch/$DB_VERSION"
+
+  # config merger script
+  chmod +x ./config-merger.sh
+
+  # download yq
+  wget https://github.com/mikefarah/yq/releases/download/$YQ_VER/yq_linux_amd64
+  chmod +x yq_linux_amd64
+  mv yq_linux_amd64 yq
+
+  local cmd="docker build --pull -t $DOCKER_REGISTRY/$IMG:$TAG ."
+  echo $cmd; $cmd
+
+  rm yq
+  popd
+}
+
+binary_repo $@

--- a/hack/docker/elasticsearch/6.8.0/run.sh
+++ b/hack/docker/elasticsearch/6.8.0/run.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+echo "Starting Elasticsearch ${ES_VERSION}"
+
+BASE=/elasticsearch
+
+# Allow for memlock if enabled
+if [ "${MEMORY_LOCK}" == "true" ]; then
+    ulimit -l unlimited
+fi
+
+# Set a random node name if not set
+if [ -z "${NODE_NAME}" ]; then
+    NODE_NAME="$(uuidgen)"
+fi
+
+# Create a temporary folder for Elasticsearch ourselves
+# ref: https://github.com/elastic/elasticsearch/pull/27659
+export ES_TMPDIR="$(mktemp -d -t elasticsearch.XXXXXXXX)"
+chmod -R 777 "$ES_TMPDIR"
+
+# Prevent "Text file busy" errors
+sync
+
+if [ ! -z "${ES_PLUGINS_INSTALL}" ]; then
+    OLDIFS="${IFS}"
+    IFS=","
+    for plugin in ${ES_PLUGINS_INSTALL}; do
+        if ! "${BASE}"/bin/elasticsearch-plugin list | grep -qs ${plugin}; then
+            until "${BASE}"/bin/elasticsearch-plugin install --batch ${plugin}; do
+                echo "Failed to install ${plugin}, retrying in 3s"
+                sleep 3
+            done
+        fi
+    done
+    IFS="${OLDIFS}"
+fi
+
+if [ ! -z "${SHARD_ALLOCATION_AWARENESS_ATTR}" ]; then
+    # this will map to a file like  /etc/hostname => /dockerhostname so reading that file will get the
+    #  container hostname
+    if [ -f "${SHARD_ALLOCATION_AWARENESS_ATTR}" ]; then
+        ES_SHARD_ATTR="$(cat "${SHARD_ALLOCATION_AWARENESS_ATTR}")"
+    else
+        ES_SHARD_ATTR="${SHARD_ALLOCATION_AWARENESS_ATTR}"
+    fi
+
+    NODE_NAME="${ES_SHARD_ATTR}-${NODE_NAME}"
+    echo "node.attr.${SHARD_ALLOCATION_AWARENESS}: ${ES_SHARD_ATTR}" >> $BASE/config/elasticsearch.yml
+
+    if [ "$NODE_MASTER" == "true" ]; then
+        echo "cluster.routing.allocation.awareness.attributes: ${SHARD_ALLOCATION_AWARENESS}" >> "${BASE}"/config/elasticsearch.yml
+    fi
+fi
+
+export NODE_NAME=${NODE_NAME}
+
+# remove x-pack-ml module
+rm -rf /elasticsearch/modules/x-pack/x-pack-ml
+rm -rf /elasticsearch/modules/x-pack-ml
+
+# Run
+if [[ $(whoami) == "root" ]]; then
+    if [ ! -d "/data/data/nodes/0" ]; then
+        echo "Changing ownership of /data folder"
+        chown -R elasticsearch:elasticsearch /data
+    fi
+    exec su-exec elasticsearch $BASE/bin/elasticsearch $ES_EXTRA_ARGS
+else
+    # The container's first process is not running as 'root',
+    # it does not have the rights to chown. However, we may
+    # assume that it is being ran as 'elasticsearch', and that
+    # the volumes already have the right permissions. This is
+    # the case for Kubernetes, for example, when 'runAsUser: 1000'
+    # and 'fsGroup:100' are defined in the pod's security context.
+    "${BASE}"/bin/elasticsearch ${ES_EXTRA_ARGS}
+fi

--- a/hack/docker/elasticsearch/6.8.0/runit.sh
+++ b/hack/docker/elasticsearch/6.8.0/runit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+set -o errexit
+set -o pipefail
+
+sync
+
+# if custom config file exist then process them
+CUSTOM_CONFIG_DIR="/elasticsearch/custom-config"
+
+if [ -d "$CUSTOM_CONFIG_DIR" ]; then
+
+  configs=($(find $CUSTOM_CONFIG_DIR -maxdepth 1 -name "*.yaml"))
+  configs+=($(find $CUSTOM_CONFIG_DIR -maxdepth 1 -name "*.yml"))
+  if [ ${#configs[@]} -gt 0 ]; then
+    config-merger.sh
+  fi
+fi
+
+echo "Starting runit..."
+exec /sbin/runsvdir -P /etc/service


### PR DESCRIPTION
Following these instructions

> 1. Fork kubedb/elasticsearch.

2. Create a new folder as same name as your expected ES version here: https://github.com/kubedb/elasticsearch/tree/master/hack/docker/elasticsearch.

3. Copy contents of 6.5.3.

4. Edit Dockerfile file of your newly created folder.
- Change ES_VERSION env to your version: https://github.com/kubedb/elasticsearch/blob/35e5b8734079ae88ccc5111d7821ff23c6d5b3d1/hack/docker/elasticsearch/6.5.3/Dockerfile#L3
- Change search-guard version to your respective version: https://github.com/kubedb/elasticsearch/blob/35e5b8734079ae88ccc5111d7821ff23c6d5b3d1/hack/docker/elasticsearch/6.5.3/Dockerfile#L68

5. Update DB_VERSION in make.sh file: https://github.com/kubedb/elasticsearch/blob/35e5b8734079ae88ccc5111d7821ff23c6d5b3d1/hack/docker/elasticsearch/6.5.3/make.sh#L10

6. Update search-guard-6 to search-gurad-7 in /fsloader/run_sgadmin.sh. https://github.com/kubedb/elasticsearch/blob/35e5b8734079ae88ccc5111d7821ff23c6d5b3d1/hack/docker/elasticsearch/6.5.3/fsloader/run_sgadmin.sh#L3

7. Do similar to /fsolder/run_fsloader.sh. https://github.com/kubedb/elasticsearch/blob/35e5b8734079ae88ccc5111d7821ff23c6d5b3d1/hack/docker/elasticsearch/6.5.3/fsloader/run_fsloader.sh#L7

8. Update elasticsearch-tools image similarly.

Example CRD
```
apiVersion: catalog.kubedb.com/v1alpha1
kind: ElasticsearchVersion
metadata:
  generation: 1
  name: 6.8.0
spec:
  db:
    image: seanmcguigan/elasticsearch:6.8.0-v2
  exporter:
    image: kubedb/elasticsearch_exporter:1.0.2
  tools:
    image: seanmcguigan/elasticsearch-tools:6.8.0
  version: 6.8.0
```