### PR TITLE
Support configuration options for exporter sidecar

### DIFF
--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -502,7 +502,7 @@ func (c *Controller) upsertMonitoringContainer(statefulSet *apps.StatefulSet, el
 				fmt.Sprintf("--es.uri=%s", getURI(elasticsearch)),
 				fmt.Sprintf("--web.listen-address=:%d", api.PrometheusExporterPortNumber),
 				fmt.Sprintf("--web.telemetry-path=%s", elasticsearch.StatsService().Path()),
-			}),
+			}, elasticsearch.Spec.Monitor.Args...),
 			Image:           elasticsearchVersion.Spec.Exporter.Image,
 			ImagePullPolicy: core.PullIfNotPresent,
 			Ports: []core.ContainerPort{


### PR DESCRIPTION
Resolves adding extra `args` to exporter sidecar. This option is implemented in [Redis](https://github.com/kubedb/redis/blob/master/pkg/controller/statefulset.go#L280-L283).