### PR TITLE
Make master service headless & add rest-port to all db nodes

### DIFF
--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -200,9 +200,11 @@ func (c *Controller) createMasterService(elasticsearch *api.Elasticsearch) (kuti
 		core_util.EnsureOwnerReference(&in.ObjectMeta, owner)
 		in.Labels = elasticsearch.OffshootLabels()
 		in.Annotations = elasticsearch.Spec.ServiceTemplate.Annotations
-
 		in.Spec.Selector = elasticsearch.OffshootSelectors()
 		in.Spec.Selector[NodeRoleMaster] = NodeRoleSet
+
+		in.Spec.Type = core.ServiceTypeClusterIP
+		in.Spec.ClusterIP = core.ClusterIPNone
 		in.Spec.Ports = core_util.MergeServicePorts(in.Spec.Ports, []core.ServicePort{defaultPeerPort})
 		return in
 	})

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -126,7 +126,7 @@ func (c *Controller) ensureStatefulSet(
 			})
 		in = upsertEnv(in, elasticsearch, esVersion, envList)
 		in = upsertUserEnv(in, elasticsearch)
-		in = upsertPort(in, isClient)
+		in = upsertPorts(in)
 		in = upsertCustomConfig(in, elasticsearch, esVersion)
 
 		in.Spec.Template.Spec.NodeSelector = elasticsearch.Spec.PodTemplate.Spec.NodeSelector
@@ -726,7 +726,7 @@ func upsertUserEnv(statefulSet *apps.StatefulSet, elasticsearch *api.Elasticsear
 	return statefulSet
 }
 
-func upsertPort(statefulSet *apps.StatefulSet, isClient bool) *apps.StatefulSet {
+func upsertPorts(statefulSet *apps.StatefulSet) *apps.StatefulSet {
 
 	getPorts := func() []core.ContainerPort {
 		portList := []core.ContainerPort{
@@ -736,13 +736,12 @@ func upsertPort(statefulSet *apps.StatefulSet, isClient bool) *apps.StatefulSet 
 				Protocol:      core.ProtocolTCP,
 			},
 		}
-		if isClient {
-			portList = append(portList, core.ContainerPort{
-				Name:          api.ElasticsearchRestPortName,
-				ContainerPort: api.ElasticsearchRestPort,
-				Protocol:      core.ProtocolTCP,
-			})
-		}
+
+		portList = append(portList, core.ContainerPort{
+			Name:          api.ElasticsearchRestPortName,
+			ContainerPort: api.ElasticsearchRestPort,
+			Protocol:      core.ProtocolTCP,
+		})
 
 		return portList
 	}


### PR DESCRIPTION
While upgrading, we need to communicate with each node (i.e. pod) separately. So,  all client, data, and master nodes should have the rest-api port.