### PR TITLE
Prepare for release v0.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200922210707-59bab27e5d41
 	kmodules.xyz/offshoot-api v0.0.0-20201027212804-f5e6dc573558
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	kubedb.dev/apimachinery v0.14.0-rc.2
+	kubedb.dev/apimachinery v0.14.0
 	sigs.k8s.io/yaml v1.2.0
 	stash.appscode.dev/apimachinery v0.11.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1599,8 +1599,8 @@ kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de h1:uWgv78OoOWx9eQdu6SEkPopvbpnL8WxZEMNd3/Oye2w=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-rc.2 h1:OcssxwH74Ubw+XqibUginieJ8gMyETd3/UQQWqtx5l4=
-kubedb.dev/apimachinery v0.14.0-rc.2/go.mod h1:JLcA8wGUyJrgAYYIybdp4OcqTv1PrhpgJsqeMjvDEhM=
+kubedb.dev/apimachinery v0.14.0 h1:XMm9yesMqKtZdUDRVWkiqzyyqlHCG3+lW+UlTgq5P4I=
+kubedb.dev/apimachinery v0.14.0/go.mod h1:JLcA8wGUyJrgAYYIybdp4OcqTv1PrhpgJsqeMjvDEhM=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1222,7 +1222,7 @@ kmodules.xyz/prober/api/v1
 ## explicit
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-rc.2
+# kubedb.dev/apimachinery v0.14.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.28
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/21
Signed-off-by: 1gtm <1gtm@appscode.com>