### PR TITLE
Prepare for release v0.17.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20201105074044-be7a1044891a
 	kmodules.xyz/offshoot-api v0.0.0-20210308072215-581e7685cd02
 	kmodules.xyz/webhook-runtime v0.0.0-20210220081624-75da115ae653
-	kubedb.dev/apimachinery v0.17.1-0.20210316094951-ad35ae90acd7
+	kubedb.dev/apimachinery v0.17.1
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1514,8 +1514,8 @@ kmodules.xyz/prober v0.0.0-20210218144026-43e923722d81/go.mod h1:2eN8X5Wq7/AAgE5
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
 kmodules.xyz/webhook-runtime v0.0.0-20210220081624-75da115ae653 h1:+ZbxtkEx8R4OWQBwZP1QMGVOt1wDxN3t+NvodNlGGtk=
 kmodules.xyz/webhook-runtime v0.0.0-20210220081624-75da115ae653/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.17.1-0.20210316094951-ad35ae90acd7 h1:1THzatCDu9nHFC9D/9hnuvynkx4t+ATxUObPeKnzwT0=
-kubedb.dev/apimachinery v0.17.1-0.20210316094951-ad35ae90acd7/go.mod h1:UNTeh+NqGnFM1D2vcMki80DH5krLijRcDsuqDwOVhxY=
+kubedb.dev/apimachinery v0.17.1 h1:qwmhZAmwaebccdCAAB7UhZPjNnjKOEns922YpdIcMTE=
+kubedb.dev/apimachinery v0.17.1/go.mod h1:UNTeh+NqGnFM1D2vcMki80DH5krLijRcDsuqDwOVhxY=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -91,6 +91,10 @@ const (
 	ElasticsearchInitConfigMergerContainerName   = "config-merger"
 	ElasticsearchContainerName                   = "elasticsearch"
 	ElasticsearchExporterContainerName           = "exporter"
+	ElasticsearchSearchGuardRolesMappingFileName = "sg_roles_mapping.yml"
+	ElasticsearchSearchGuardInternalUserFileName = "sg_internal_users.yml"
+	ElasticsearchOpendistroRolesMappingFileName  = "roles_mapping.yml"
+	ElasticsearchOpendistroInternalUserFileName  = "internal_users.yml"
 
 	// Ref:
 	//	- https://www.elastic.co/guide/en/elasticsearch/reference/7.6/heap-size.html#heap-size

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
@@ -647,6 +647,6 @@ func getElasticsearchUser(userList map[string]ElasticsearchUserSpec, username st
 	if !hasElasticsearchUser(userList, username) {
 		return nil, errors.New("user is missing")
 	}
-	userSpec, _ := userList[username]
+	userSpec := userList[username]
 	return &userSpec, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1122,7 +1122,7 @@ kmodules.xyz/prober/api/v1
 ## explicit
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.17.1-0.20210316094951-ad35ae90acd7
+# kubedb.dev/apimachinery v0.17.1
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.03.17
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/35
Signed-off-by: 1gtm <1gtm@appscode.com>